### PR TITLE
tagがグローバルに書き換えられてしまう問題、url.query が nil 時にエラーになる問題を fix

### DIFF
--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -34,8 +34,9 @@ module Fluent
 
     def emit(tag, es, chain)
       es.each do |time, record|
-        filter_record(tag, time, record)
-        Engine.emit(tag, time, record)
+        t = tag.dup
+        filter_record(t, time, record)
+        Engine.emit(t, time, record)
       end
 
       chain.next
@@ -45,15 +46,17 @@ module Fluent
       if record[key]
         begin
           url = URI.parse(record[key])
-          url.query.split('&').each do |pair|
-            key, value = pair.split('=').map { |i| URI.unescape(i) }
+          unless url.query.nil?
+            url.query.split('&').each do |pair|
+              key, value = pair.split('=').map { |i| URI.unescape(i) }
 
-            if only
-              record[key] = value if @include_keys.has_key?(key)
-            elsif except
-              record[key] = value if !@exclude_keys.has_key?(key)
-            else
-              record[key] = value
+              if only
+                record[key] = value if @include_keys.has_key?(key)
+              elsif except
+                record[key] = value if !@exclude_keys.has_key?(key)
+              else
+                record[key] = value
+              end
             end
           end
         rescue URI::InvalidURIError => error

--- a/test/plugin/test_out_extract_query_params.rb
+++ b/test/plugin/test_out_extract_query_params.rb
@@ -102,6 +102,29 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
     assert_equal 'qux',            emits[0][2]['baz']
   end
 
+  def test_emit_multi
+    d = create_driver(%[
+      key            url
+      add_tag_prefix extracted.
+      only           foo, baz
+    ])
+    d.run do
+      d.emit('url' => URL)
+      d.emit('url' => URL)
+      d.emit('url' => URL)
+    end
+    emits = d.emits
+
+    assert_equal 3, emits.count
+
+    emits.each do |e|
+      assert_equal 'extracted.test', e[0]
+      assert_equal URL,              e[2]['url']
+      assert_equal 'bar',            e[2]['foo']
+      assert_equal 'qux',            e[2]['baz']
+    end
+  end
+
   def test_emit_without_match_key
     d = create_driver(%[
       key            no_such_key


### PR DESCRIPTION
通常のテストでは問題無かったのですが、実際に nginx のアクセスログを source に使ってみたところ初回ループのみ extract_query_params plugin を通りそれ以降は通らない、という不具合がありました。

HandleTagNameMixin はメモリ上にある tag をコピーせずに書き換えるので、二度目以降のループで既に tag が extracted.hogehoge になったまま入力に入り、match hoge ではマッチしなくなる、というのが原因でした。

本プラグインのように再 emit 時に filter_record を発行する場合は一度 dup してから書き換える必要があるようです。
