### PR TITLE
optionally remove the original URL key

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ If set, only the key/value whose key is included `only` will be added to the rec
 
 If set, the key/value whose key is included `except` will NOT be added to the record.
 
+### discard_key
+
+If set to `true`, the original `key` url will be discarded from the record. Defaults to `false` (preserve key).
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -9,6 +9,7 @@ module Fluent
     config_param :key,    :string
     config_param :only,   :string, :default => nil
     config_param :except, :string, :default => nil
+    config_param :discard_key, :bool, :default => false
 
     def configure(conf)
       super
@@ -59,6 +60,7 @@ module Fluent
               end
             end
           end
+          record.delete key if discard_key
         rescue URI::InvalidURIError => error
           $log.warn("out_extract_query_params: #{error.message}")
         end

--- a/test/plugin/test_out_extract_query_params.rb
+++ b/test/plugin/test_out_extract_query_params.rb
@@ -86,6 +86,24 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
     assert_nil record['モリス']
   end
 
+  def test_filter_record_with_discard
+    d = create_driver(%[
+      key            url
+      add_tag_prefix extracted.
+      discard_key true
+    ])
+
+    tag    = 'test'
+    record = { 'url' => URL }
+    d.instance.filter_record('test', Time.now, record)
+
+    assert_nil               record['nil']
+    assert_nil               record['url']
+    assert_equal 'bar',      record['foo']
+    assert_equal 'qux',      record['baz']
+    assert_equal 'すたじお', record['モリス']
+  end
+
   def test_emit
     d = create_driver(%[
       key            url


### PR DESCRIPTION
By setting `discard_key true`, the original URL key may be discarded.

```
"extracted.test" => {
  "foo" => "bar",
  "baz" => "qux"
}
```
