### PR TITLE
option to add prefix of output field name

### DIFF
--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -10,6 +10,7 @@ module Fluent
     config_param :only,   :string, :default => nil
     config_param :except, :string, :default => nil
     config_param :discard_key, :bool, :default => false
+    config_param :add_field_prefix, :string, :default => nil
 
     def configure(conf)
       super
@@ -51,6 +52,7 @@ module Fluent
             url.query.split('&').each do |pair|
               key, value = pair.split('=').map { |i| URI.unescape(i) }
 
+              key = @add_field_prefix + key if @add_field_prefix
               if only
                 record[key] = value if @include_keys.has_key?(key)
               elsif except

--- a/test/plugin/test_out_extract_query_params.rb
+++ b/test/plugin/test_out_extract_query_params.rb
@@ -52,6 +52,28 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
     assert_equal 'すたじお', record['モリス']
   end
 
+  def test_filter_record_with_field_prefix
+    d = create_driver(%[
+      key            url
+      add_field_prefix query_
+      add_tag_prefix extracted.
+    ])
+
+    tag    = 'test'
+    record = {
+      'url' => URL,
+    }
+    d.instance.filter_record('test', Time.now, record)
+
+    assert_equal URL,       record['url']
+    assert_nil record['foo']
+    assert_nil record['baz']
+    assert_nil record['モリス']
+    assert_equal 'bar',     record['query_foo']
+    assert_equal 'qux',     record['query_baz']
+    assert_equal 'すたじお', record['query_モリス']
+  end
+
   def test_filter_record_with_only
     d = create_driver(%[
       key            url


### PR DESCRIPTION
add new option to separate parsed values from original fields by specified prefix, like 'q_' or 'query_' and so on.
