### PR TITLE
Update fluent-plugin-extract_query_params.gemspec

### DIFF
--- a/fluent-plugin-extract_query_params.gemspec
+++ b/fluent-plugin-extract_query_params.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'fluentd'
   gem.add_runtime_dependency     'fluentd'
 end


### PR DESCRIPTION
duplication of development and runtime dependency breaks dependency information on rubygems.org
