### PR TITLE
Ignore extra '=' in values

### DIFF
--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -90,7 +90,7 @@ module Fluent
 
           unless url.query.nil?
             url.query.split('&').each do |pair|
-              key, value = pair.split('=').map { |i| URI.unescape(i) }
+              key, value = pair.split('=', 2).map { |i| URI.unescape(i) }
               next if (key.nil? || key.empty?) && (!@permit_blank_key || value.nil? || value.empty?)
               key ||= ''
               value ||= ''

--- a/test/plugin/test_out_extract_query_params.rb
+++ b/test/plugin/test_out_extract_query_params.rb
@@ -226,7 +226,6 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
       d.emit({ 'path' => DIRTY_PATH_BASE64_2 })
       d.emit({ 'path' => DIRTY_PATH_BASE64_3 })
       d.emit({ 'path' => DIRTY_PATH_BASE64_4 })
-
     }
     emits = d.emits
 

--- a/test/plugin/test_out_extract_query_params.rb
+++ b/test/plugin/test_out_extract_query_params.rb
@@ -202,6 +202,10 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
   DIRTY_PATH_KEY_ONLY_3 = '/dummy?baz=qux&foo'
   DIRTY_PATH_VALUE_ONLY_1 = '/dummy?=bar&baz=qux'
   DIRTY_PATH_VALUE_ONLY_2 = '/dummy?baz=qux&=bar'
+  DIRTY_PATH_BASE64_1 = '/dummy?foo=ZXh0cmE=&baz=qux'
+  DIRTY_PATH_BASE64_2 = '/dummy?baz=qux&foo=ZXh0cmE='
+  DIRTY_PATH_BASE64_3 = '/dummy?foo=cGFkZGluZw==&baz=qux'
+  DIRTY_PATH_BASE64_4 = '/dummy?baz=qux&foo=cGFkZGluZw=='
 
   def test_emit_with_dirty_paths
     d = create_driver(%[
@@ -218,10 +222,15 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
       d.emit({ 'path' => DIRTY_PATH_KEY_ONLY_3 })
       d.emit({ 'path' => DIRTY_PATH_VALUE_ONLY_1 })
       d.emit({ 'path' => DIRTY_PATH_VALUE_ONLY_2 })
+      d.emit({ 'path' => DIRTY_PATH_BASE64_1 })
+      d.emit({ 'path' => DIRTY_PATH_BASE64_2 })
+      d.emit({ 'path' => DIRTY_PATH_BASE64_3 })
+      d.emit({ 'path' => DIRTY_PATH_BASE64_4 })
+
     }
     emits = d.emits
 
-    assert_equal 9, emits.count
+    assert_equal 13, emits.count
 
     r = emits.shift[2]
     assert_equal 2, r.size
@@ -271,6 +280,30 @@ class ExtractQueryParamsOutputTest < Test::Unit::TestCase
     assert_equal 2, r.size
     assert_equal DIRTY_PATH_VALUE_ONLY_2, r['path']
     assert_equal 'qux',                   r['baz']
+
+    r = emits.shift[2]
+    assert_equal 3, r.size
+    assert_equal DIRTY_PATH_BASE64_1, r['path']
+    assert_equal 'qux',               r['baz']
+    assert_equal 'ZXh0cmE=',          r['foo']
+
+    r = emits.shift[2]
+    assert_equal 3, r.size
+    assert_equal DIRTY_PATH_BASE64_2, r['path']
+    assert_equal 'qux',               r['baz']
+    assert_equal 'ZXh0cmE=',          r['foo']
+
+    r = emits.shift[2]
+    assert_equal 3, r.size
+    assert_equal DIRTY_PATH_BASE64_3, r['path']
+    assert_equal 'qux',               r['baz']
+    assert_equal 'cGFkZGluZw==',      r['foo']
+
+    r = emits.shift[2]
+    assert_equal 3, r.size
+    assert_equal DIRTY_PATH_BASE64_4, r['path']
+    assert_equal 'qux',               r['baz']
+    assert_equal 'cGFkZGluZw==',      r['foo']
   end
 
   def test_emit_with_permit_blank_key


### PR DESCRIPTION
Hello !

Thank you for your work.
I use this plugin parsing Apache logs URLs, and sometimes, one parameter value is base64 and contain '=' padding.
As is, this plugin will ignore the extra '=' in the value.

This pull request forces the '=' split to stop parsing when *2* values are extracted, causing the value to contain the whole string, including the '='.

Extremely simple. Tests added too.