### PR TITLE
Use router.emit instead of Engine.emit

### DIFF
--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -49,7 +49,7 @@ module Fluent
       es.each do |time, record|
         t = tag.dup
         filter_record(t, time, record)
-        Engine.emit(t, time, record)
+        router.emit(t, time, record)
       end
 
       chain.next

--- a/lib/fluent/plugin/out_extract_query_params.rb
+++ b/lib/fluent/plugin/out_extract_query_params.rb
@@ -6,6 +6,11 @@ module Fluent
 
     Fluent::Plugin.register_output('extract_query_params', self)
 
+    # To support Fluentd v0.10.57 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :key,    :string
     config_param :only,   :string, :default => nil
     config_param :except, :string, :default => nil


### PR DESCRIPTION
Fluentd 0.10.58 or later supports router.emit API.
When using this API, it will be label feature enabled.