### PR TITLE
Fix error in real world

### DIFF
--- a/lib/fluent/plugin/query_params_extractor.rb
+++ b/lib/fluent/plugin/query_params_extractor.rb
@@ -10,7 +10,7 @@ module Fluent
     def initialize(plugin, conf)
       @log = plugin.log
 
-      if plugin.instance_of?(Fluent::ExtractQueryParamsOutput)
+      if plugin.is_a?(Fluent::Output)
         unless have_tag_option?(plugin)
           raise ConfigError, "out_extract_query_params: At least one of remove_tag_prefix/remove_tag_suffix/add_tag_prefix/add_tag_suffix is required to be set."
         end


### PR DESCRIPTION
Fluentd does not read output plugin files when we use filter plugin.

```text
$ bundle exec fluentd -c fluent.conf
2015-09-08 14:06:00 +0900 [info]: reading config file path="fluent.conf"
2015-09-08 14:06:00 +0900 [info]: starting fluentd-0.12.15
2015-09-08 14:06:00 +0900 [info]: gem 'fluentd' version '0.12.15'
2015-09-08 14:06:00 +0900 [info]: gem 'fluent-plugin-extract_query_params' version '0.0.11'
2015-09-08 14:06:00 +0900 [info]: adding filter pattern="raw.**" type="extract_query_params"
2015-09-08 14:06:00 +0900 [error]: unexpected error error="uninitialized constant Fluent::ExtractQueryParamsOutput"
```